### PR TITLE
Refine validation rule management and controller responses

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -11,5 +11,11 @@ return [
 
     'forms' => [
 
-    ]
+    ],
+
+    'cache' => [
+        'enabled' => true,
+        'ttl' => 300,
+        'store' => null,
+    ],
 ];

--- a/src/FormRequestServiceProvider.php
+++ b/src/FormRequestServiceProvider.php
@@ -107,6 +107,17 @@ class FormRequestServiceProvider extends ServiceProvider
             });
         }
 
+        if(!ResponseFactory::hasMacro('jsonNotFound')) {
+            ResponseFactory::macro('jsonNotFound', function ($data = null) {
+                $response = ['success' => false];
+                if (!is_null($data)) {
+                    $response['message'] = $data;
+                }
+
+                return response()->json($response, 404);
+            });
+        }
+
         if(!ResponseFactory::hasMacro('jsonNotValidated')) {
             ResponseFactory::macro('jsonNotValidated', function ($message = null, $error = null) {
                 $response = ['success' => false];

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -3,29 +3,40 @@
 namespace RiseTechApps\FormRequest\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use RiseTechApps\FormRequest\Http\Requests\StoreFormRequest;
 use RiseTechApps\FormRequest\Http\Requests\UpdateFormRequest;
 use RiseTechApps\FormRequest\Http\Resources\FormRequestResource;
 use RiseTechApps\FormRequest\Models\FormRequest;
-use RiseTechApps\FormRequest\Rules;
-use RiseTechApps\FormRequest\ValidationRuleRepository;
+use Throwable;
 
 class FormController extends Controller
 {
+    public function __construct(private readonly FormRequest $forms)
+    {
+    }
+
     public function index(Request $request): JsonResponse
     {
         try {
+            $query = $this->forms->newQuery();
 
-            $model = new FormRequest();
+            if ($request->filled('form')) {
+                $query->where('form', $request->query('form'));
+            }
 
-            $data = FormRequestResource::collection($model->all());
+            $perPage = (int) $request->query('per_page', 15);
+
+            $data = $perPage <= 0
+                ? FormRequestResource::collection($query->get())
+                : FormRequestResource::collection($query->paginate(max($perPage, 1)));
 
             logglyInfo()->withRequest($request)->log("Successfully loaded datatable");
 
             return response()->jsonSuccess($data);
-        } catch (\Exception $exception) {
+        } catch (Throwable $exception) {
 
             logglyError()->exception($exception)->withRequest($request)->log("Error loading datatable");
 
@@ -36,13 +47,12 @@ class FormController extends Controller
     public function store(StoreFormRequest $request): JsonResponse
     {
         try {
-            $model = new FormRequest();
-            $model->create($request->validationData());
+            $form = $this->forms->create($request->validationData());
 
-            logglyInfo()->withRequest($request)->performedOn($model)->log("Success when registering registration");
+            logglyInfo()->withRequest($request)->performedOn($form)->log("Success when registering registration");
 
-            return response()->jsonSuccess();
-        } catch (\Exception $exception) {
+            return response()->jsonSuccess(FormRequestResource::make($form));
+        } catch (Throwable $exception) {
 
             logglyError()->exception($exception)->withRequest($request)->performedOn(self::class)
                 ->withTags(['action' => 'store'])->log("Error by registering registration");
@@ -54,13 +64,17 @@ class FormController extends Controller
     public function show(Request $request): JsonResponse
     {
         try {
-            $model = new FormRequest();
-            $data = FormRequestResource::make( $model->find($request->id));
+            $form = $this->forms->newQuery()->findOrFail($request->route('id'));
+            $data = FormRequestResource::make($form);
 
-            logglyInfo()->withRequest($request)->performedOn($model)->log("Success when loading the record for viewing");
+            logglyInfo()->withRequest($request)->performedOn($form)->log("Success when loading the record for viewing");
 
             return response()->jsonSuccess($data);
-        } catch (\Exception $exception) {
+        } catch (ModelNotFoundException $exception) {
+            logglyError()->exception($exception)->withRequest($request)->log("Record not found for viewing");
+
+            return response()->jsonNotFound("Form request not found");
+        } catch (Throwable $exception) {
 
             logglyError()->exception($exception)->withRequest($request)->log("Error when loading the record to be viewed");
 
@@ -72,15 +86,19 @@ class FormController extends Controller
     {
 
         try {
-            $model = new FormRequest();
-            $model = $model->find($request->id);
-            $update = $model->update($request->validationData());
+            $form = $this->forms->newQuery()->findOrFail($request->route('id'));
+            $form->fill($request->validationData());
+            $form->save();
 
-            logglyInfo()->withRequest($request)->performedOn($model)->log("Success by updating the registration");
+            logglyInfo()->withRequest($request)->performedOn($form)->log("Success by updating the registration");
 
-            return response()->jsonSuccess($update);
+            return response()->jsonSuccess(FormRequestResource::make($form->refresh()));
 
-        } catch (\Exception $exception) {
+        } catch (ModelNotFoundException $exception) {
+            logglyError()->exception($exception)->withRequest($request)->log("Record not found for update");
+
+            return response()->jsonNotFound("Form request not found");
+        } catch (Throwable $exception) {
 
             logglyError()->exception($exception)->withRequest($request)->log("Error update the registration");
 
@@ -88,25 +106,22 @@ class FormController extends Controller
         }
     }
 
-    public function delete(Request $request): JsonResponse
+    public function destroy(Request $request): JsonResponse
     {
         try {
+            $form = $this->forms->newQuery()->findOrFail($request->route('id'));
 
-            $model = new FormRequest();
-            $data = $model->find($request->id);
+            $form->delete();
 
-            if($data->delete()){
-                logglyInfo()->withRequest($request)->performedOn($model)->log("Success by deleting the record");
+            logglyInfo()->withRequest($request)->performedOn($form)->log("Success by deleting the record");
 
-                return response()->jsonSuccess();
+            return response()->jsonSuccess();
 
-            }else{
-                logglyError()->withRequest($request)->log("Error by deleting the record");
+        } catch (ModelNotFoundException $exception) {
+            logglyError()->exception($exception)->withRequest($request)->log("Record not found for deletion");
 
-                return response()->jsonGone("Error by deleting the record");
-            }
-
-        } catch (\Exception $exception) {
+            return response()->jsonNotFound("Form request not found");
+        } catch (Throwable $exception) {
 
             logglyError()->exception($exception)->withRequest($request)->log("Error by deleting the record");
 

--- a/src/Http/Requests/StoreFormRequest.php
+++ b/src/Http/Requests/StoreFormRequest.php
@@ -3,6 +3,8 @@
 namespace RiseTechApps\FormRequest\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
 use RiseTechApps\FormRequest\Traits\hasFormValidation\hasFormValidation;
 use RiseTechApps\FormRequest\ValidationRuleRepository;
 
@@ -39,9 +41,32 @@ class StoreFormRequest extends FormRequest
 
     public function messages(): array
     {
-        return array_map(function ($value) {
-            return __('formrequest::validation.' . $value);
-        }, $this->result['messages']);
+        return array_map(function (string $value) {
+            $packageKey = 'formrequest::validation.' . $value;
+            if (Lang::has($packageKey)) {
+                return __($packageKey);
+            }
+
+            [$attribute, $rule] = array_pad(explode('.', $value, 2), 2, null);
+
+            $customKey = sprintf('validation.custom.%s.%s', $attribute, $rule);
+            if ($attribute && $rule && Lang::has($customKey)) {
+                return __($customKey);
+            }
+
+            $fallbackKey = 'validation.' . $rule;
+            if ($rule && Lang::has($fallbackKey)) {
+                $readableAttribute = Str::of((string) $attribute)
+                    ->replace('_', ' ')
+                    ->lower()
+                    ->ucfirst()
+                    ->toString();
+
+                return __($fallbackKey, ['attribute' => $readableAttribute]);
+            }
+
+            return $value;
+        }, $this->messages);
     }
 
 }

--- a/src/Http/Requests/UpdateFormRequest.php
+++ b/src/Http/Requests/UpdateFormRequest.php
@@ -3,6 +3,8 @@
 namespace RiseTechApps\FormRequest\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Str;
 use RiseTechApps\FormRequest\Traits\hasFormValidation\hasFormValidation;
 use RiseTechApps\FormRequest\ValidationRuleRepository;
 
@@ -41,8 +43,31 @@ class UpdateFormRequest extends FormRequest
 
     public function messages(): array
     {
-        return array_map(function ($value) {
-            return __('formrequest::validation.' . $value);
-        }, $this->result['messages']);
+        return array_map(function (string $value) {
+            $packageKey = 'formrequest::validation.' . $value;
+            if (Lang::has($packageKey)) {
+                return __($packageKey);
+            }
+
+            [$attribute, $rule] = array_pad(explode('.', $value, 2), 2, null);
+
+            $customKey = sprintf('validation.custom.%s.%s', $attribute, $rule);
+            if ($attribute && $rule && Lang::has($customKey)) {
+                return __($customKey);
+            }
+
+            $fallbackKey = 'validation.' . $rule;
+            if ($rule && Lang::has($fallbackKey)) {
+                $readableAttribute = Str::of((string) $attribute)
+                    ->replace('_', ' ')
+                    ->lower()
+                    ->ucfirst()
+                    ->toString();
+
+                return __($fallbackKey, ['attribute' => $readableAttribute]);
+            }
+
+            return $value;
+        }, $this->messages);
     }
 }

--- a/src/ValidationRuleRepository.php
+++ b/src/ValidationRuleRepository.php
@@ -2,90 +2,179 @@
 
 namespace RiseTechApps\FormRequest;
 
-use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Str;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Support\Arr;
 use RiseTechApps\FormRequest\Models\FormRequest as FormRequestModel;
 
 class ValidationRuleRepository
 {
+    private CacheRepository $cache;
+
+    private bool $cacheEnabled;
+
+    private int $cacheTtl;
+
+    public function __construct(
+        private readonly FormRequestModel $forms,
+        CacheFactory $cacheFactory
+    ) {
+        $cacheConfig = config('rules.cache', []);
+        $this->cacheEnabled = (bool) ($cacheConfig['enabled'] ?? false);
+        $this->cacheTtl = (int) ($cacheConfig['ttl'] ?? 300);
+        $store = $cacheConfig['store'] ?? null;
+        $this->cache = $store ? $cacheFactory->store($store) : $cacheFactory->store();
+    }
 
     public function getRules(string $name, array $parameter = []): array
     {
+        $cachedParameters = Arr::except($parameter, ['id']);
+        $cacheKey = $this->cacheKey($name, $cachedParameters);
 
-        $validationRules = [
-            'rules'=> [],
-            'messages' => []
-        ];
+        $validationRules = $this->remember($cacheKey, function () use ($name, $cachedParameters) {
+            $rulesFromDatabase = $this->fetchRulesFromDatabase($name, $cachedParameters);
 
-        $model = new FormRequestModel();
-
-        $where = array_merge([
-            'form' => $name
-        ], $parameter);
-
-        $results = $model
-            ->where($where)
-            ->first(['rules']);
-
-        if (!empty($results)) {
-            $validationRules = $results->toArray();
-            $validationRules['messages'] = $this->generateMessages($validationRules['rules']);
-        } else {
-
-            $default = Rules::defaultRules();
-
-            if (array_key_exists($name, $default)) {
-                $validationRules['rules'] = $default[$name];
-                $validationRules['messages'] = $this->generateMessages($validationRules['rules']);
+            if (!empty($rulesFromDatabase['rules'])) {
+                return $rulesFromDatabase;
             }
-        }
+
+            return $this->fetchRulesFromConfiguration($name);
+        });
 
         if (array_key_exists('id', $parameter)) {
             $validationRules['rules'] = $this->setIdUpdate($parameter['id'], $validationRules['rules']);
         }
+
         return $validationRules;
     }
 
     protected function generateMessages(array $rules): array
     {
         $messages = [];
+
         foreach ($rules as $key => $value) {
-            $messages = array_merge($messages,
-                $this->extractRules($key, $value));
+            $messages = array_merge($messages, $this->extractRules($key, $value));
         }
 
         return $messages;
     }
 
-    protected function extractRules($field, $rulesString): array
+    protected function extractRules(string $field, mixed $rulesDefinition): array
     {
-        $formattedRules = [];
-        foreach (explode('|', $rulesString) as $rule) {
-            $r = trim(explode(':', $rule)[0]);
+        $rules = is_array($rulesDefinition) ? $rulesDefinition : explode('|', (string) $rulesDefinition);
 
-            $r = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $r));
-            $formattedRules[$field . '.' .$r] = $field . '.' . $r;
+        $formattedRules = [];
+
+        foreach ($rules as $rule) {
+            if (!is_string($rule) || $rule === '') {
+                continue;
+            }
+
+            $normalizedRule = trim(explode(':', $rule)[0]);
+            $normalizedRule = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $normalizedRule));
+
+            $messageKey = $field . '.' . $normalizedRule;
+            $formattedRules[$field . '.' . $normalizedRule] = $messageKey;
         }
 
         return $formattedRules;
-
     }
 
-    private function setIdUpdate(mixed $id, $rules): array
+    private function setIdUpdate(mixed $id, array $rules): array
     {
         return array_map(function ($rule) use ($id) {
-            if (str_contains($rule, 'unique:') || str_contains($rule, 'unique')) {
-                $parts = explode('|', $rule);
-                foreach ($parts as &$part) {
-                    if (str_contains($part, 'unique:')) {
-                        $part .= ',' . $id;
-                    }else if (str_contains($part, 'unique')) {
-                        $part .= ':' . $id;
-                    }
-                }
-                return implode('|', $parts);
+            if (!is_string($rule)) {
+                return $rule;
             }
-            return $rule;
+
+            $parts = array_map('trim', explode('|', $rule));
+
+            foreach ($parts as &$part) {
+                if (!str_starts_with($part, 'unique:')) {
+                    continue;
+                }
+
+                $segments = explode(',', $part);
+                if (isset($segments[2])) {
+                    $segments[2] = (string) $id;
+                } else {
+                    $segments[] = (string) $id;
+                }
+
+                $part = implode(',', $segments);
+            }
+
+            return implode('|', $parts);
         }, $rules);
+    }
+
+    private function fetchRulesFromDatabase(string $name, array $parameter = []): array
+    {
+        $where = array_merge(['form' => $name], $parameter);
+
+        $result = $this->forms->newQuery()
+            ->where($where)
+            ->first(['rules']);
+
+        if (empty($result)) {
+            return [
+                'rules' => [],
+                'messages' => [],
+            ];
+        }
+
+        $rules = (array) $result->rules;
+
+        return [
+            'rules' => $rules,
+            'messages' => $this->generateMessages($rules),
+        ];
+    }
+
+    private function fetchRulesFromConfiguration(string $name): array
+    {
+        $defaults = Rules::defaultRules();
+
+        if (!array_key_exists($name, $defaults)) {
+            return [
+                'rules' => [],
+                'messages' => [],
+            ];
+        }
+
+        $configuration = $defaults[$name];
+
+        if (is_array($configuration) && array_key_exists('rules', $configuration)) {
+            $rules = (array) $configuration['rules'];
+            $messages = $configuration['messages'] ?? $this->generateMessages($rules);
+        } else {
+            $rules = (array) $configuration;
+            $messages = $this->generateMessages($rules);
+        }
+
+        return [
+            'rules' => $rules,
+            'messages' => $messages,
+        ];
+    }
+
+    private function cacheKey(string $name, array $parameter = []): string
+    {
+        if (empty($parameter)) {
+            return sprintf('form-request:%s', $name);
+        }
+
+        ksort($parameter);
+
+        return sprintf('form-request:%s:%s', $name, md5(json_encode($parameter)));
+    }
+
+    private function remember(string $key, callable $callback): array
+    {
+        if (!$this->cacheEnabled) {
+            return $callback();
+        }
+
+        return $this->cache->remember($key, $this->cacheTtl, $callback);
     }
 }


### PR DESCRIPTION
## Summary
- add configurable caching for validation rules and improve repository fallbacks
- update package form requests to surface translated messages without relying on undefined properties
- refactor the form controller responses and macros for better routing, pagination, and error handling

## Testing
- `php -l src/Http/Controllers/FormController.php`
- `php -l src/Http/Requests/StoreFormRequest.php`
- `php -l src/Http/Requests/UpdateFormRequest.php`
- `php -l src/ValidationRuleRepository.php`
- `php -l src/FormRequestServiceProvider.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690c147fc0ec8320917fe6ad3ef52b77)